### PR TITLE
fix for building depgraph for Maven and Ivy Projects

### DIFF
--- a/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
+++ b/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
@@ -77,7 +77,7 @@ public abstract class AbstractDependencyGraphAction implements Action {
     private static final Comparator<AbstractProject<?,?>> PROJECT_COMPARATOR = new Comparator<AbstractProject<?,?>>() {
         @Override
         public int compare(AbstractProject<?,?> o1, AbstractProject<?,?> o2) {
-            return o1.getFullName().compareTo(o2.getFullName());
+            return o1.getFullDisplayName().compareTo(o2.getFullDisplayName());
         }
     };
 


### PR DESCRIPTION
simple change of `project.getName()` to `project.getFullName()` and `project.getFullDisplayName()` to ensure uniqueness when using with multi-module Maven and Ivy Projects that are configured to build their modules as separate jobs.
