### PR TITLE
Changing the direction of the graph

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,4 +79,19 @@
     <developerConnection>scm:git:git@github.com:jenkinsci/depgraph-view-plugin.git</developerConnection>
     <url>http://github.com/jenkinsci/depgraph-view-plugin</url>
   </scm>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+
+  
 </project>

--- a/src/main/java/hudson/plugins/depgraph_view/DotStringGenerator.java
+++ b/src/main/java/hudson/plugins/depgraph_view/DotStringGenerator.java
@@ -137,6 +137,7 @@ public class DotStringGenerator {
 
         builder.append("digraph {\n");
         builder.append("node [shape=box, style=rounded];\n");
+        builder.append("rankdir=LR;\n");
 
         /**** First define all the objects and clusters ****/
 


### PR DESCRIPTION
... from top-to-bottom to left-to-right, since:

1) webapps don't normally scroll horizontally
2) job names can be long and so each node tends to be wider than taller.

This visualization works better.
