### PR TITLE
use same color for new dep connectors

### DIFF
--- a/src/main/webapp/js/jsPlumb_depview.js
+++ b/src/main/webapp/js/jsPlumb_depview.js
@@ -15,7 +15,6 @@
         paper: jQuery("#paper"),
         colordep: '#FF0000', // red
         colorcopy: '#32CD32', // green
-        colordepnew: '#FFFF00', // yellow
         init : function() {
             jsPlumb.importDefaults({
                 Connector : ["StateMachine", { curviness: 10 }],// Straight, Flowchart, Straight, Bezier
@@ -37,10 +36,11 @@
                     radius : 6
                 } ] ],
 
-                // connector line 2px
+                // def for new connector (drag n' drop) 
+                // - line 2px
                 PaintStyle : {
                     lineWidth : 2,
-                    strokeStyle : window.depview.colordepnew,
+                    strokeStyle : window.depview.colordep,
                     joinstyle:"round"},
 
                 // the overlays to decorate each connection with. note that the


### PR DESCRIPTION
Users seem to be confused to have a dependency connector created with a new color. 
This pull request uses the same color (red) for existing and new dep connectors
