### PR TITLE
disable wrapping of jobnames

### DIFF
--- a/src/main/webapp/css/depview.css
+++ b/src/main/webapp/css/depview.css
@@ -32,6 +32,7 @@
 	font-family: helvetica;
     padding: 0.5em 1em;
     font-size: 0.9em;
+    white-space: nowrap;
 }
 
 .window:hover {


### PR DESCRIPTION
Some of our jobs are quite long and might contain spaces or dashes, these names are wrapped by the browser. This leads to overlapping boxes in the graph.
This pull request stops the browser to wrap the jobnames within a box - resulting in the same display as if there where now spaces in the name. 
