### PR TITLE
fix invalid ajax calls

### DIFF
--- a/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/index.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/index.jelly
@@ -24,7 +24,7 @@
   <j:choose>
     <j:when test="${it.isGraphvizEnabled()}">
 	  <l:layout title="${it.title}">
-	    <st:include it="${it.parentObject}" page="sidepanel.jelly" />
+	    <st:include page="sidepanel.jelly" />
 	    <l:main-panel>
 	      <h1>${%Dependency Graph}</h1>
 	      <l:tabBar>

--- a/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/jsplumb.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/jsplumb.jelly
@@ -25,7 +25,7 @@
   <j:new var="h2" className="hudson.Functions" /><!-- instead of JSP functions -->
   <link rel="stylesheet" href="${h2.inferHudsonURL(context.currentRequest)}/plugin/depgraph-view/css/depview.css"></link>
 	<l:layout title="${it.title}">
-		<st:include it="${it.parentObject}" page="sidepanel.jelly" />
+		<st:include page="sidepanel.jelly" />
 		<l:main-panel>
 			<h1>${%Dependency Graph}</h1>
 

--- a/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/sidepanel.jelly
@@ -1,0 +1,34 @@
+<!--
+The MIT License
+
+Copyright (c) 2012, Dominik Bartholdi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <l:header />
+  <l:side-panel>
+    <l:tasks>
+      <l:task icon="images/24x24/up.png" href=".." title="${%Back}" contextMenu="false"/>
+      <l:task icon="images/24x24/setting.gif" href="${rootURL}/manage" title="${%Manage Jenkins}" />
+    </l:tasks>
+    <t:executors computers="${h.singletonList(it)}" />
+  </l:side-panel>
+</j:jelly>


### PR DESCRIPTION
this pull request adds a generic sitepannel.jelly, to get rid of the invalid ajax calls to:
- .../depgraph-view/ajaxExecutors 
- .../depgraph-view/ajaxBuildQueue

This calls are caused by the executors list in the sidepannel, but even though the sitepannel is included from the parent object, the calls are made to the depgraph-view which does not provide this information.

An other possibility to fix this issue, would be to implement these calls in the `AbstractDependencyGraphAction`
