### PR TITLE
[FIXED JENKINS-9007] enable to strip job names of redundant strings

### DIFF
--- a/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
+++ b/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
@@ -169,6 +169,14 @@ public abstract class AbstractDependencyGraphAction implements Action {
     public boolean isEditFunctionInJSViewEnabled() {
         return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class).isEditFunctionInJSViewEnabled();
     }
+    
+    public String getProjectNameStripRegex() {
+        return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegex();
+    }
+    
+    public int getProjectNameStripRegexGroup() {
+        return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegexGroup();
+    }    
 
     /**
      * @return projects for which the dependency graph should be calculated

--- a/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
+++ b/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
@@ -28,7 +28,15 @@ import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import javax.servlet.ServletException;
+
 import net.sf.json.JSONObject;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -51,6 +59,10 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
         private boolean graphvizEnabled = true;
 
         private boolean editFunctionInJSViewEnabled = false;
+        
+        private String projectNameStripRegex = ".*";
+        
+        private int projectNameStripRegexGroup = 1;
 
         public DescriptorImpl() {
             load();
@@ -67,6 +79,8 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
                 graphvizEnabled = false;
             }
             editFunctionInJSViewEnabled  = o.optBoolean("editFunctionInJSViewEnabled");
+            projectNameStripRegex  = o.optString("projectNameStripRegex", ".*");
+            projectNameStripRegexGroup = o.optInt("projectNameStripRegexGroup", 1);
 
             save();
 
@@ -88,6 +102,14 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
 
         public boolean isEditFunctionInJSViewEnabled() {
             return editFunctionInJSViewEnabled;
+        }
+
+        public String getProjectNameStripRegex() {
+            return projectNameStripRegex;
+        }
+
+        public int getProjectNameStripRegexGroup() {
+            return projectNameStripRegexGroup;
         }
 
         /**
@@ -118,6 +140,24 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
 
         public FormValidation doCheckDotExe(@QueryParameter final String value) {
             return FormValidation.validateExecutable(value);
+        }
+        
+        public FormValidation doCheckProjectNameStripRegex(@QueryParameter final String value) 
+                    throws IOException, ServletException {
+                String pattern = Util.fixEmptyAndTrim(value);
+                if (pattern == null) {
+                    return FormValidation.error(Messages.DependencyGraphProperty_ProjectNameStripRegex_Required());
+                }
+                try {
+                    Pattern.compile(pattern);
+                } catch (PatternSyntaxException e) {
+                    return FormValidation.error(Messages.DependencyGraphProperty_ProjectNameStripRegex_Invalid());
+                }
+                return FormValidation.ok();
+        }
+        
+        public FormValidation doCheckProjectNameStripRegexGroup(@QueryParameter final String value) {
+            return FormValidation.validatePositiveInteger(value);
         }
 
     }

--- a/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
+++ b/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
@@ -123,6 +123,16 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
             }
         }
 
+        public synchronized void setProjectNameStripRegexGroup(int projectNameStripRegexGroup) {
+            this.projectNameStripRegexGroup = projectNameStripRegexGroup;
+            save();
+        }
+        
+        public synchronized void setProjectNameStripRegex(String projectNameStripRegex) {
+            this.projectNameStripRegex = projectNameStripRegex;
+            save();
+        }
+        
         public synchronized void setDotExe(String dotPath) {
             this.dotExe = dotPath;
             save();

--- a/src/main/java/hudson/plugins/depgraph_view/model/display/DotStringGenerator.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/display/DotStringGenerator.java
@@ -78,11 +78,12 @@ public class DotStringGenerator extends AbstractDotStringGenerator {
     }
     
     private final StripFunction stripFunction;
-            
-    public DotStringGenerator(DependencyGraph graph, ListMultimap<ProjectNode, ProjectNode> projects2Subprojects) {
+    
+    
+    public DotStringGenerator(Jenkins jenkins, DependencyGraph graph, ListMultimap<ProjectNode, ProjectNode> projects2Subprojects) {
         super(graph, projects2Subprojects);
-        int projectNameStripRegexGroup = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegexGroup();
-        final String projectNameStripRegex = Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegex();
+        int projectNameStripRegexGroup = jenkins.getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegexGroup();
+        final String projectNameStripRegex = jenkins.getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegex();
         
         Pattern nameStripPattern = null;
         try {
@@ -92,6 +93,10 @@ public class DotStringGenerator extends AbstractDotStringGenerator {
         }
         
         stripFunction = new StripFunction(nameStripPattern, projectNameStripRegexGroup);
+    }
+            
+    public DotStringGenerator(DependencyGraph graph, ListMultimap<ProjectNode, ProjectNode> projects2Subprojects) {
+        this(Jenkins.getInstance(), graph, projects2Subprojects);
     }
 
     /**

--- a/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/jsplumb.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/jsplumb.jelly
@@ -44,7 +44,11 @@
 
 			<script type='text/javascript' src='${rootURL}/plugin/depgraph-view/js/jquery.jsPlumb-1.4.1-all-min.js'></script>
 			<script type="text/javascript" src="${rootURL}/plugin/depgraph-view/js/jsPlumb_depview.js"></script>
-      <script type="text/javascript">window.depview.editEnabled=${it.isEditFunctionInJSViewEnabled()}</script>
+      <script type="text/javascript">
+      window.depview.editEnabled=${it.isEditFunctionInJSViewEnabled()};
+      window.depview.projectNameStripRegex=/${it.getProjectNameStripRegex()}/g;
+      window.depview.projectNameStripRegexGroup=${it.getProjectNameStripRegexGroup()};
+      </script>
 
 		</l:main-panel>
 	</l:layout>

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.properties
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.properties
@@ -21,3 +21,4 @@
 #
 
 editFunctionInJSViewEnabled=Enable edit functiononality in jsplumb view
+projectNameStripRegex=Strip the project names

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegex.html
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegex.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010 Stefan Wolf
+  ~ Copyright (c) 2013 Dominik Bartholdi
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,8 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${%Dependency Graph Viewer Configuration}">
-    <f:optionalBlock name="graphviz" title="${%Enable rendering with graphviz}" checked="${descriptor.isGraphvizEnabled()}">
-	    <f:entry title="${%Dot Executable Path}" field="dotExe">
-	      <f:textbox value="${descriptor.getDotExe()}"/>
-	    </f:entry>
-    </f:optionalBlock>
-    <f:entry field="editFunctionInJSViewEnabled" title="${%editFunctionInJSViewEnabled}">
-        <f:checkbox checked="${instance.isEditFunctionInJSViewEnabled()}" />
-    </f:entry>
-    <f:entry field="projectNameStripRegex" title="${%projectNameStripRegex}">
-        <f:textbox />
-    </f:entry>
-    <f:entry field="projectNameStripRegexGroup" title="${%projectNameStripRegexGroup}">
-        <f:textbox />
-    </f:entry>    
-  </f:section>
-</j:jelly>
+<div>
+  Some companies have naming conventions, this often results in long names which take to much space when displayed. This setting lets you define a global regular expression to define what part of the full name should be shown in the graphs. Default is <code>.*</code>, which shows the full name.<br />
+  <code>com.comp.proj.(.*)</code> will strip 'com.comp.proj' from every project name.<br />
+  With the group definition one can define the group of the given regex to be used.    
+</div>

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegexGroup.html
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegexGroup.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010 Stefan Wolf
+  ~ Copyright (c) 2013 Dominik Bartholdi
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,6 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${%Dependency Graph Viewer Configuration}">
-    <f:optionalBlock name="graphviz" title="${%Enable rendering with graphviz}" checked="${descriptor.isGraphvizEnabled()}">
-	    <f:entry title="${%Dot Executable Path}" field="dotExe">
-	      <f:textbox value="${descriptor.getDotExe()}"/>
-	    </f:entry>
-    </f:optionalBlock>
-    <f:entry field="editFunctionInJSViewEnabled" title="${%editFunctionInJSViewEnabled}">
-        <f:checkbox checked="${instance.isEditFunctionInJSViewEnabled()}" />
-    </f:entry>
-    <f:entry field="projectNameStripRegex" title="${%projectNameStripRegex}">
-        <f:textbox />
-    </f:entry>
-    <f:entry field="projectNameStripRegexGroup" title="${%projectNameStripRegexGroup}">
-        <f:textbox />
-    </f:entry>    
-  </f:section>
-</j:jelly>
+<div>
+  Allows to define the group of regular expression to be used for to display as the job name, defaults to <code>1</code>.
+</div>

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegexGroup_de.html
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegexGroup_de.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010 Stefan Wolf
+  ~ Copyright (c) 2013 Dominik Bartholdi
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,6 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${%Dependency Graph Viewer Configuration}">
-    <f:optionalBlock name="graphviz" title="${%Enable rendering with graphviz}" checked="${descriptor.isGraphvizEnabled()}">
-	    <f:entry title="${%Dot Executable Path}" field="dotExe">
-	      <f:textbox value="${descriptor.getDotExe()}"/>
-	    </f:entry>
-    </f:optionalBlock>
-    <f:entry field="editFunctionInJSViewEnabled" title="${%editFunctionInJSViewEnabled}">
-        <f:checkbox checked="${instance.isEditFunctionInJSViewEnabled()}" />
-    </f:entry>
-    <f:entry field="projectNameStripRegex" title="${%projectNameStripRegex}">
-        <f:textbox />
-    </f:entry>
-    <f:entry field="projectNameStripRegexGroup" title="${%projectNameStripRegexGroup}">
-        <f:textbox />
-    </f:entry>    
-  </f:section>
-</j:jelly>
+<div>
+  Erlaubt es zu definieren welche Gruppe aus der RegularExpression als Job Name im DependencyGraph angezeigt werden soll, Defaults ist <code>1</code>. 
+</div>

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegex_de.html
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-projectNameStripRegex_de.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010 Stefan Wolf
+  ~ Copyright (c) 2013 Dominik Bartholdi
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,21 +20,10 @@
   ~ THE SOFTWARE.
   -->
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <f:section title="${%Dependency Graph Viewer Configuration}">
-    <f:optionalBlock name="graphviz" title="${%Enable rendering with graphviz}" checked="${descriptor.isGraphvizEnabled()}">
-	    <f:entry title="${%Dot Executable Path}" field="dotExe">
-	      <f:textbox value="${descriptor.getDotExe()}"/>
-	    </f:entry>
-    </f:optionalBlock>
-    <f:entry field="editFunctionInJSViewEnabled" title="${%editFunctionInJSViewEnabled}">
-        <f:checkbox checked="${instance.isEditFunctionInJSViewEnabled()}" />
-    </f:entry>
-    <f:entry field="projectNameStripRegex" title="${%projectNameStripRegex}">
-        <f:textbox />
-    </f:entry>
-    <f:entry field="projectNameStripRegexGroup" title="${%projectNameStripRegexGroup}">
-        <f:textbox />
-    </f:entry>    
-  </f:section>
-</j:jelly>
+<div>
+  Einige Firmen/Organisationen haben Namenskonventionen für ihr Jobs definiert, dies kann zu sehr langen namen führen und damit zu einer unübersichtlichen Ansicht der Jobabhängigkeiten.<br />
+  Diese Option ermöglicht es mittels einer RegularExpression nur einen Teil des Jobnamens im Dependencygraph anzeigen zu lassen.   
+  Default ist <code>.*</code>, welches den ganzen Namen anzeigt.<br />
+  <code>com.comp.proj.(.*)</code> wird 'com.comp.proj' vom Namen entfernen.<br />
+  Mit der Gruppenangabe kann zusätzlich Angabe werden welche Gruppe der RegularExpression benutzt werden soll.    
+</div>

--- a/src/main/resources/hudson/plugins/depgraph_view/Messages.properties
+++ b/src/main/resources/hudson/plugins/depgraph_view/Messages.properties
@@ -23,3 +23,5 @@
 AbstractDependencyGraphAction.DependencyGraphOf=Dependency Graph of {0}
 AbstractDependencyGraphAction.DependencyGraph=Dependency Graph
 DependencyGraphProperty.DependencyGraphViewer=Dependency Graph Viewer
+DependencyGraphProperty.ProjectNameStripRegex.Required=A Regular Expression is required
+DependencyGraphProperty.ProjectNameStripRegex.Invalid=The given expression is not valid

--- a/src/main/webapp/js/jsPlumb_depview.js
+++ b/src/main/webapp/js/jsPlumb_depview.js
@@ -6,6 +6,16 @@
         // rethink the strategy
         return id.replace(/[^a-zA-Z0-9]/g,'-');
     }
+    
+    function stripName(name) {
+    	if(window.depview.projectNameStripRegex) {
+    		match = window.depview.projectNameStripRegex.exec(name);
+    		if(match && match[window.depview.projectNameStripRegexGroup]){
+    			return match[window.depview.projectNameStripRegexGroup];
+    		}
+    		return name;
+    	}
+    }    
 
     function getJobDiv(jobName) {
         return jQuery('#' + escapeId(jobName));
@@ -68,7 +78,7 @@
                         if (window.depview.editEnabled) {
                             nodeString = nodeString + '<div class="ep"/>';
                         }
-                        nodeString = nodeString + '<a href="' + node.url + '">' + node.name + '</a></div>'
+                        nodeString = nodeString + '<a href="' + node.url + '">' + stripName(node.name) + '</a></div>'
                         jQuery(nodeString).
                             addClass('window').
                             attr('id', escapeId(node.name)).

--- a/src/test/java/hudson/plugins/depgraph_view/model/graph/StripProjectNameTest.java
+++ b/src/test/java/hudson/plugins/depgraph_view/model/graph/StripProjectNameTest.java
@@ -1,0 +1,53 @@
+package hudson.plugins.depgraph_view.model.graph;
+
+import static hudson.plugins.depgraph_view.model.graph.ProjectNode.node;
+import static org.junit.Assert.assertTrue;
+import hudson.model.AbstractProject;
+import hudson.model.FreeStyleProject;
+import hudson.plugins.depgraph_view.DependencyGraphProperty.DescriptorImpl;
+import hudson.plugins.depgraph_view.model.display.DotStringGenerator;
+
+import java.util.Collections;
+
+import jenkins.model.JenkinsLocationConfiguration;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ListMultimap;
+
+public class StripProjectNameTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void projectNameShouldBeStriped() throws Exception {
+        JenkinsLocationConfiguration.get().setUrl("http://localhost");
+        j.getInstance().getDescriptorByType(DescriptorImpl.class).setProjectNameStripRegex("com.comp.(.*)");
+        j.getInstance().getDescriptorByType(DescriptorImpl.class).setProjectNameStripRegexGroup(1);
+        
+        final FreeStyleProject myJob = j.createFreeStyleProject("com.comp.myJob");
+        j.getInstance().rebuildDependencyGraph();
+        DependencyGraph graph = generateGraph(myJob);
+        final SubprojectCalculator subprojectCalculator = new SubprojectCalculator(Collections.<SubProjectProvider>emptySet());
+        final ListMultimap<ProjectNode, ProjectNode> subProjects = subprojectCalculator.generate(graph);
+        final DotStringGenerator dotStringGenerator = new DotStringGenerator(j.getInstance(), graph, subProjects);
+        final String dotString = dotStringGenerator.generate();
+        
+        // we can't test for not existing of the original name, because that one is still required for linking, 
+        // so we explicitly check for the short/striped version only
+        assertTrue("the partial name should be active now", dotString.contains("\"myJob\""));
+        
+    }
+
+    private DependencyGraph generateGraph(AbstractProject<?,?> from) {
+        return new GraphCalculator(getDependencyGraphEdgeProviders()).generateGraph(Collections.singleton(node(from)));
+    }
+    
+    private ImmutableSet<EdgeProvider> getDependencyGraphEdgeProviders() {
+        return ImmutableSet.<EdgeProvider>of(new DependencyGraphEdgeProvider(j.getInstance()));
+    }
+}


### PR DESCRIPTION
Some companies have naming conventions, this often results in long names which take to much space when displayed. This PR enables admins to define a RegEx to be used to shorten the display names of job in the DependenyGraph.

https://issues.jenkins-ci.org/browse/JENKINS-9007
