### PR TITLE
Allow to set graphviz rank direction

### DIFF
--- a/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
+++ b/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProperty.java
@@ -59,12 +59,14 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
         private boolean graphvizEnabled = true;
 
         private boolean editFunctionInJSViewEnabled = false;
-        
+
         private String projectNameStripRegex = ".*";
-        
+
         private int projectNameStripRegexGroup = 1;
-        
+
         private int projectNameSuperscriptRegexGroup = -1;
+
+        private String graphRankDirection = "TB";
 
         public DescriptorImpl() {
             load();
@@ -84,7 +86,7 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
             setProjectNameStripRegex(o.optString("projectNameStripRegex", ".*"));
             setProjectNameStripRegexGroup(o.optInt("projectNameStripRegexGroup", 1));
             setProjectNameSuperscriptRegexGroup(o.optInt("projectNameSuperscriptRegexGroup", 1));
-
+            setGraphRankDirection(o.optString("graphRankDirection", "TB"));
             save();
 
             return true;
@@ -119,6 +121,10 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
             return projectNameSuperscriptRegexGroup;
         }
 
+        public synchronized String getGraphRankDirection() {
+            return graphRankDirection;
+        }
+
         /**
          * @return configured dot executable or a default
          */
@@ -144,7 +150,12 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
             this.projectNameStripRegex = projectNameStripRegex;
             save();
         }
-        
+
+       public synchronized void setGraphRankDirection(String graphRankDirection) {
+            this.graphRankDirection = graphRankDirection;
+            save();
+        }
+
         public synchronized void setDotExe(String dotPath) {
             this.dotExe = dotPath;
             save();
@@ -154,7 +165,7 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
             this.graphvizEnabled = graphvizEnabled;
             save();
         }
-        
+
         public void setEditFunctionInJSViewEnabled(boolean editFunctionInJSViewEnabled) {
             this.editFunctionInJSViewEnabled = editFunctionInJSViewEnabled;
             save();
@@ -163,7 +174,7 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
         public FormValidation doCheckDotExe(@QueryParameter final String value) {
             return FormValidation.validateExecutable(value);
         }
-        
+
         public FormValidation doCheckProjectNameStripRegex(@QueryParameter final String value) 
                     throws IOException, ServletException {
                 String pattern = Util.fixEmptyAndTrim(value);
@@ -177,7 +188,7 @@ public class DependencyGraphProperty extends AbstractDescribableImpl<DependencyG
                 }
                 return FormValidation.ok();
         }
-        
+
         public FormValidation doCheckProjectNameStripRegexGroup(@QueryParameter final String value) {
             return FormValidation.validatePositiveInteger(value);
         }

--- a/src/main/java/hudson/plugins/depgraph_view/model/display/DotStringGenerator.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/display/DotStringGenerator.java
@@ -43,6 +43,8 @@ import static com.google.common.collect.Lists.transform;
  * Generates a dot string representation of the graph
  */
 public class DotStringGenerator extends AbstractDotStringGenerator {
+
+    private String rankDirection;
     private static final Function<String, String> ESCAPE = new Function<String, String>() {
         @Override
         public String apply(String from) {
@@ -93,6 +95,7 @@ public class DotStringGenerator extends AbstractDotStringGenerator {
         int projectNameStripRegexGroup = jenkins.getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegexGroup();
         final String projectNameStripRegex = jenkins.getDescriptorByType(DescriptorImpl.class).getProjectNameStripRegex();
         int projectNameSuperscriptRegexGroup = jenkins.getDescriptorByType(DescriptorImpl.class).getProjectNameSuperscriptRegexGroup();
+        this.rankDirection = jenkins.getDescriptorByType(DescriptorImpl.class).getGraphRankDirection();
 
         Pattern nameStripPattern = null;
         try {
@@ -119,6 +122,7 @@ public class DotStringGenerator extends AbstractDotStringGenerator {
 
         builder.append("digraph {\n");
         builder.append("node [shape=box, style=rounded];\n");
+        builder.append("rankdir=").append(rankDirection).append(";\n");
 
         /**** First define all the objects and clusters ****/
 

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.jelly
@@ -41,5 +41,8 @@
     <f:entry field="projectNameSuperscriptRegexGroup" title="${%projectNameSuperscriptRegexGroup}">
         <f:textbox />
     </f:entry>
+    <f:entry field="graphRankDirection" title="${%graphRankDirection}">
+        <f:textbox />
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.properties
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/global.properties
@@ -22,3 +22,4 @@
 
 editFunctionInJSViewEnabled=Enable edit functiononality in jsplumb view
 projectNameStripRegex=Strip the project names
+graphRankDirection=Graphviz rank direction

--- a/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-graphRankDirection.html
+++ b/src/main/resources/hudson/plugins/depgraph_view/DependencyGraphProperty/help-graphRankDirection.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2010 Stefan Wolf
+  ~ Copyright (c) 2013 Dominik Bartholdi
   ~
   ~ Permission is hereby granted, free of charge, to any person obtaining a copy
   ~ of this software and associated documentation files (the "Software"), to deal
@@ -20,15 +20,7 @@
   ~ THE SOFTWARE.
   -->
 
-<?jelly escape-by-default='true'?>
-
-<!--
-  This view is used to render the plugin list page.
-
-  Since we don't really have anything dynamic here, let's just use static HTML.
--->
-<?jelly escape-by-default='true'?>
 <div>
-  This plugin shows a dependency graph of the projects.
-  It uses dot (from graphviz) or jsPlumb for drawing.
+  The direction used by graphviz to layout graph nodes.<br />
+  Can be set to <code>TB</code> (top to bottom) or <code>LR</code> (left to right), default is <code>TB</code>.
 </div>


### PR DESCRIPTION
By default rank direction is 'TB' which looks good for small to medium graphs. 
This PR allows to set the rank direction to LR for having better dense graph layouts.