### PR TITLE
Fix #23 JENKINS-62797

### DIFF
--- a/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProjectActionFactory.java
+++ b/src/main/java/hudson/plugins/depgraph_view/DependencyGraphProjectActionFactory.java
@@ -1,0 +1,18 @@
+package hudson.plugins.depgraph_view;
+
+import java.util.Collection;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Action;
+import hudson.model.TransientProjectActionFactory;
+
+@Extension
+public class DependencyGraphProjectActionFactory extends TransientProjectActionFactory {
+
+    @Override
+    public Collection<? extends Action> createFor(AbstractProject target) {
+        return new DependencyGraphActionFactory().createFor(target);
+    }
+    
+}

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/DependencyGraphModule.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/DependencyGraphModule.java
@@ -23,6 +23,7 @@
 package hudson.plugins.depgraph_view.model.graph;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Key;
 import com.google.inject.multibindings.Multibinder;
 
 import hudson.Extension;
@@ -35,6 +36,8 @@ import hudson.plugins.depgraph_view.model.graph.edge.ParameterizedTriggerBuilder
 import hudson.plugins.depgraph_view.model.graph.edge.ParameterizedTriggerEdgeProvider;
 import hudson.plugins.depgraph_view.model.graph.edge.PipelineGraphPublisherEdgeProvider;
 import hudson.plugins.depgraph_view.model.graph.edge.ReverseBuildTriggerEdgeProvider;
+import hudson.plugins.depgraph_view.model.graph.project.ParameterizedTriggerSubProjectProvider;
+import hudson.plugins.depgraph_view.model.graph.project.SubProjectProvider;
 
 /**
  * Guice Module for the DependencyGraph
@@ -52,7 +55,7 @@ public class DependencyGraphModule extends AbstractModule {
         edgeProviderMultibinder.addBinding().to(CopyArtifactEdgeProvider.class);
         edgeProviderMultibinder.addBinding().to(PipelineGraphPublisherEdgeProvider.class);
         edgeProviderMultibinder.addBinding().to(DependencyGraphEdgeProvider.class);
-        Multibinder<SubProjectProvider> subProjectProviderMultibinder = Multibinder.newSetBinder(binder(), SubProjectProvider.class);
+        Multibinder<SubProjectProvider> subProjectProviderMultibinder = Multibinder.newSetBinder(binder(),Key.get(SubProjectProvider.class));
         subProjectProviderMultibinder.addBinding().to(ParameterizedTriggerSubProjectProvider.class);
     }
 }

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/EdgeProvider.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/EdgeProvider.java
@@ -22,35 +22,23 @@
 
 package hudson.plugins.depgraph_view.model.graph;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-
-import hudson.plugins.depgraph_view.model.graph.project.SubProjectProvider;
-
-import javax.inject.Inject;
-import java.util.Collection;
-import java.util.Set;
+import hudson.ExtensionPoint;
+import hudson.model.Job;
+import hudson.plugins.depgraph_view.model.graph.DependencyGraphModule;
+import hudson.plugins.depgraph_view.model.graph.edge.Edge;
 
 /**
- * Used to calculate the subprojects of a project given a set of providers.
+ * This interface is only here to not break other plugin extensions.
+ * 
+ * This is an extension point which makes it possible to add edges
+ * to the DependencyGraph which gets drawn. Note that in order to add your own
+ * EdgeProvider you must not annotate the corresponding subclass with {@link hudson.Extension}
+ * but instead add a {@link com.google.inject.Module} with a {@link com.google.inject.multibindings.Multibinder}
+ * which has the {@link hudson.Extension} annotation. For example see {@link DependencyGraphModule}
+ * and {@link DependencyGraphEdgeProvider}
  */
-public class SubprojectCalculator {
-
-    private Set<SubProjectProvider> providers;
-
-    @Inject
-    public SubprojectCalculator(Set<SubProjectProvider> providers) {
-        this.providers = providers;
-    }
-
-    public ListMultimap<ProjectNode, ProjectNode> generate(DependencyGraph graph) {
-        ListMultimap<ProjectNode, ProjectNode> project2Subprojects = ArrayListMultimap.create();
-        Collection<ProjectNode> nodes = graph.getNodes();
-        for (ProjectNode node : nodes) {
-            for (SubProjectProvider provider : providers) {
-                project2Subprojects.putAll(node, provider.getSubProjectsOf(node.getProject()));
-            }
-        }
-        return project2Subprojects;
-    }
+@Deprecated
+public interface EdgeProvider extends ExtensionPoint {
+    public Iterable<Edge> getUpstreamEdgesIncidentWith(Job<?,?> project);
+    public Iterable<Edge> getDownstreamEdgesIncidentWith(Job<?,?> project);
 }

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/GraphCalculator.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/GraphCalculator.java
@@ -22,22 +22,22 @@
 
 package hudson.plugins.depgraph_view.model.graph;
 
+import static hudson.plugins.depgraph_view.model.graph.ProjectNode.node;
+
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import hudson.model.Item;
 import hudson.model.Job;
 import hudson.plugins.depgraph_view.model.graph.edge.Edge;
 import hudson.plugins.depgraph_view.model.graph.edge.EdgeProvider;
-import hudson.model.Item;
-
-import javax.annotation.Nonnull;
-import javax.inject.Inject;
-import java.util.List;
-import java.util.Set;
-
-import static hudson.plugins.depgraph_view.model.graph.ProjectNode.node;
 
 /**
  * Generates the {@link DependencyGraph} given a set of {@link EdgeProvider}s.

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/SubProjectProvider.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/SubProjectProvider.java
@@ -24,8 +24,13 @@ package hudson.plugins.depgraph_view.model.graph;
 
 import hudson.ExtensionPoint;
 import hudson.model.Job;
+import hudson.plugins.depgraph_view.model.graph.DependencyGraphModule;
+import hudson.plugins.depgraph_view.model.graph.ProjectNode;
+import hudson.plugins.depgraph_view.model.graph.project.ParameterizedTriggerSubProjectProvider;
 
 /**
+ * This interface is only here to not break other plugin extensions.
+ * 
  * This is an extension point which makes it possible to subprojects
  * to the DependencyGraph which gets drawn. Note that in order to add your own
  * EdgeProvider you must not annotate the corresponding subclass with {@link hudson.Extension}
@@ -33,6 +38,7 @@ import hudson.model.Job;
  * which has the {@link hudson.Extension} annotation. For example see {@link DependencyGraphModule}
  * and {@link ParameterizedTriggerSubProjectProvider}
  */
+@Deprecated  
 public interface SubProjectProvider extends ExtensionPoint {
     public Iterable<ProjectNode> getSubProjectsOf(Job<?,?> project);
 }

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/project/ParameterizedTriggerSubProjectProvider.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/project/ParameterizedTriggerSubProjectProvider.java
@@ -20,12 +20,13 @@
  * THE SOFTWARE.
  */
 
-package hudson.plugins.depgraph_view.model.graph;
+package hudson.plugins.depgraph_view.model.graph.project;
 
 import com.google.common.base.Preconditions;
 import hudson.model.Job;
 import hudson.model.FreeStyleProject;
 import hudson.model.Items;
+import hudson.plugins.depgraph_view.model.graph.ProjectNode;
 import hudson.plugins.parameterizedtrigger.BlockableBuildTriggerConfig;
 import hudson.plugins.parameterizedtrigger.TriggerBuilder;
 import hudson.tasks.Builder;

--- a/src/main/java/hudson/plugins/depgraph_view/model/graph/project/SubProjectProvider.java
+++ b/src/main/java/hudson/plugins/depgraph_view/model/graph/project/SubProjectProvider.java
@@ -20,37 +20,21 @@
  * THE SOFTWARE.
  */
 
-package hudson.plugins.depgraph_view.model.graph;
+package hudson.plugins.depgraph_view.model.graph.project;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-
-import hudson.plugins.depgraph_view.model.graph.project.SubProjectProvider;
-
-import javax.inject.Inject;
-import java.util.Collection;
-import java.util.Set;
+import hudson.ExtensionPoint;
+import hudson.model.Job;
+import hudson.plugins.depgraph_view.model.graph.DependencyGraphModule;
+import hudson.plugins.depgraph_view.model.graph.ProjectNode;
 
 /**
- * Used to calculate the subprojects of a project given a set of providers.
+ * This is an extension point which makes it possible to subprojects
+ * to the DependencyGraph which gets drawn. Note that in order to add your own
+ * EdgeProvider you must not annotate the corresponding subclass with {@link hudson.Extension}
+ * but instead add a {@link com.google.inject.Module} with a {@link com.google.inject.multibindings.Multibinder}
+ * which has the {@link hudson.Extension} annotation. For example see {@link DependencyGraphModule}
+ * and {@link ParameterizedTriggerSubProjectProvider}
  */
-public class SubprojectCalculator {
-
-    private Set<SubProjectProvider> providers;
-
-    @Inject
-    public SubprojectCalculator(Set<SubProjectProvider> providers) {
-        this.providers = providers;
-    }
-
-    public ListMultimap<ProjectNode, ProjectNode> generate(DependencyGraph graph) {
-        ListMultimap<ProjectNode, ProjectNode> project2Subprojects = ArrayListMultimap.create();
-        Collection<ProjectNode> nodes = graph.getNodes();
-        for (ProjectNode node : nodes) {
-            for (SubProjectProvider provider : providers) {
-                project2Subprojects.putAll(node, provider.getSubProjectsOf(node.getProject()));
-            }
-        }
-        return project2Subprojects;
-    }
+public interface SubProjectProvider extends ExtensionPoint {
+    public Iterable<ProjectNode> getSubProjectsOf(Job<?,?> project);
 }

--- a/src/test/java/hudson/plugins/depgraph_view/model/graph/StripProjectNameTest.java
+++ b/src/test/java/hudson/plugins/depgraph_view/model/graph/StripProjectNameTest.java
@@ -7,6 +7,7 @@ import hudson.model.FreeStyleProject;
 import hudson.plugins.depgraph_view.DependencyGraphProperty.DescriptorImpl;
 import hudson.plugins.depgraph_view.model.graph.edge.DependencyGraphEdgeProvider;
 import hudson.plugins.depgraph_view.model.graph.edge.EdgeProvider;
+import hudson.plugins.depgraph_view.model.graph.project.SubProjectProvider;
 import hudson.plugins.depgraph_view.model.display.DotStringGenerator;
 
 import java.util.Collections;


### PR DESCRIPTION
Some refactoring to allow unmaintained maven-cascade-release plugin to not break jenkins