### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/depgraph_view/AbstractDependencyGraphAction/sidepanel.jelly
@@ -24,12 +24,12 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:t="/lib/hudson">
   <l:header />
   <l:side-panel>
     <l:tasks>
-      <l:task icon="images/24x24/up.png" href=".." title="${%Back}" contextMenu="false"/>
-      <l:task icon="images/24x24/setting.gif" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}"/>
+      <l:task icon="icon-up icon-md" href=".." title="${%Back}" contextMenu="false"/>
+      <l:task icon="icon-setting icon-md" href="${rootURL}/manage" title="${%Manage Jenkins}" permission="${app.ADMINISTER}"/>
     </l:tasks>
     <t:executors computers="${h.singletonList(it)}" />
   </l:side-panel>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @guidograzioli 
Thanks in advance!