### PR TITLE
Require 2.452.4 and replace gif by themable symbol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,13 +26,15 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.77</version>
+        <version>4.88</version>
         <relativePath />
     </parent>
     <properties>
         <revision>1.0.6</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.414.3</jenkins.version>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.452</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -64,8 +66,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.414.x</artifactId>
-                <version>2718.v7e8a_d43b_3f0b_</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>3875.v1df09947cde6</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -97,6 +99,13 @@
         <dependency>
             <groupId>net.sf.jung</groupId>
             <artifactId>jung-graph-impl</artifactId>
+            <exclusions>
+              <!-- Provided by core -->
+              <exclusion>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+              </exclusion>
+            </exclusions>
             <version>2.1.1</version>
         </dependency>
         <dependency>

--- a/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
+++ b/src/main/java/hudson/plugins/depgraph_view/AbstractDependencyGraphAction.java
@@ -208,7 +208,7 @@ public abstract class AbstractDependencyGraphAction implements Action {
 
     @Override
     public String getIconFileName() {
-        return "graph.gif";
+        return "symbol-graph plugin-depgraph-view";
     }
 
     @Override

--- a/src/main/resources/images/symbols/graph.svg
+++ b/src/main/resources/images/symbols/graph.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13.5 7L17 10.5" stroke="currentColor" stroke-linecap="round"></path>
+    <path d="M7 13.5L10.5 17" stroke="currentColor" stroke-linecap="round"></path>
+    <path d="M10.5 7L7 10.5" stroke="currentColor" stroke-linecap="round"></path>
+    <path d="M17 13.5L13.5 17" stroke="currentColor" stroke-linecap="round"></path>
+    <circle cx="12" cy="5.5" r="2" stroke="currentColor"></circle>
+    <circle cx="12" cy="18.5" r="2" stroke="currentColor"></circle>
+    <circle cx="5.5" cy="12" r="2" stroke="currentColor"></circle>
+    <circle cx="18.5" cy="12" r="2" stroke="currentColor"></circle>
+    <circle cx="5.5" cy="12" r="0.5" stroke="currentColor"></circle>
+    <circle cx="12" cy="18.5" r="0.5" stroke="currentColor"></circle>
+</svg>


### PR DESCRIPTION
Require 2.452.4 and replace gif by themable symbol

### Testing done

![Screenshot from 2025-01-06 09-06-41](https://github.com/user-attachments/assets/e101fa39-dd1f-46f1-b876-8a4a1c38b262)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
